### PR TITLE
Fix zipalign for Android Gradle Plugin 4.1.0

### DIFF
--- a/lib/signing.js
+++ b/lib/signing.js
@@ -24,7 +24,7 @@ function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPasswo
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Zipaligning APK file");
         // Find zipalign executable
-        const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.2';
+        const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.3';
         const androidHome = process.env.ANDROID_HOME;
         const buildTools = path.join(androidHome, `build-tools/${buildToolsVersion}`);
         if (!fs.existsSync(buildTools)) {
@@ -35,7 +35,11 @@ function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPasswo
         // Align the apk file
         const alignedApkFile = apkFile.replace('.apk', '-aligned.apk');
         yield exec.exec(`"${zipAlign}"`, [
+            '-c',
             '-v', '4',
+            apkFile
+        ]);
+        yield exec.exec(`"cp"`, [
             apkFile,
             alignedApkFile
         ]);

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -15,7 +15,7 @@ export async function signApkFile(
     core.debug("Zipaligning APK file");
 
     // Find zipalign executable
-    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.2';
+    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.3';
     const androidHome = process.env.ANDROID_HOME;
     const buildTools = path.join(androidHome!, `build-tools/${buildToolsVersion}`);
     if (!fs.existsSync(buildTools)) {
@@ -28,7 +28,12 @@ export async function signApkFile(
     // Align the apk file
     const alignedApkFile = apkFile.replace('.apk', '-aligned.apk');
     await exec.exec(`"${zipAlign}"`, [
+        '-c',
         '-v', '4',
+        apkFile
+    ]);
+    
+    await exec.exec(`"cp"`, [
         apkFile,
         alignedApkFile
     ]);


### PR DESCRIPTION
The Android Gradle Plugin v4.1.0 outputs aligned APKs, so we just do a zipalign check rather than actually trying to align it.
Linked issue https://issuetracker.google.com/issues/162117652