### PR TITLE
update default build-tools version from 29.0.3 to 33.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then copy the contents of the `.txt` file to your GH secrets
 
 ## ENV: `BUILD_TOOLS_VERSION`
 
-**Optional:** You can manually specify a version of build-tools to use. We use `29.0.3` by default.
+**Optional:** You can manually specify a version of build-tools to use. We use `34.0.0` by default.
 
 ## Outputs
 
@@ -68,8 +68,8 @@ steps:
       keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
       keyPassword: ${{ secrets.KEY_PASSWORD }}
     env:
-      # override default build-tools version (29.0.3) -- optional
-      BUILD_TOOLS_VERSION: "30.0.2"
+      # override default build-tools version (33.0.0) -- optional
+      BUILD_TOOLS_VERSION: "34.0.0"
 
   # Example use of `signedReleaseFile` output -- not needed
   - uses: actions/upload-artifact@v2

--- a/lib/signing.js
+++ b/lib/signing.js
@@ -38,7 +38,7 @@ function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPasswo
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Zipaligning APK file");
         // Find zipalign executable
-        const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.3';
+        const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '33.0.0';
         const androidHome = process.env.ANDROID_HOME;
         const buildTools = path.join(androidHome, `build-tools/${buildToolsVersion}`);
         if (!fs.existsSync(buildTools)) {

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -15,7 +15,7 @@ export async function signApkFile(
     core.debug("Zipaligning APK file");
 
     // Find zipalign executable
-    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '29.0.3';
+    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '33.0.0';
     const androidHome = process.env.ANDROID_HOME;
     const buildTools = path.join(androidHome!, `build-tools/${buildToolsVersion}`);
     if (!fs.existsSync(buildTools)) {


### PR DESCRIPTION
Due to the default build-tools version 29.0.3 becoming somewhat old, builds started failing with the latest runner images like `ubuntu-latest.

ps: This PR updates to 33.0.0 and not to 34.0.0 for backward compatibility reasons with some old runner versions