### PR TITLE
Update: node version to 'node20'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,5 @@ outputs:
   signedReleaseFile12:
     description: 'The 12th signed release APK or AAB file'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'lib/main.js'


### PR DESCRIPTION
fixes https://github.com/r0adkll/sign-android-release/issues/83 updating the action to use **`node20`**