### PR TITLE
bump to node24 version, required from Sept. 2026 on Github

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,5 @@ outputs:
   signedReleaseFile12:
     description: 'The 12th signed release APK or AAB file'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'lib/main.js'


### PR DESCRIPTION
Github is deprcating `node.js` 20 jobs. This PR bumps up the `node.js` version to 24. I successfully use this change to sign APKs and AAP, unfortunately this is a propietary repo and I can't share the Github Actions run. If required to review this change, I can setup a standalone + public repo to demonstrate that the change works.

I prepare an additional PR (to be merged after this one) which also bumps up the `node.js` packages in the repo, as some of the are outdated.

For reference, full Github warning on `node.js` 20 deprecation:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work
as expected: softprops/action-gh-release@v2. Actions will be forced to run with Node.js 24 by default
starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please
check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24
now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in
your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting 
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/
changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```